### PR TITLE
Update CONTRIBUTING.md with link to Adobe CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This project adheres to the Adobe [code of conduct](CODE_OF_CONDUCT.md). By part
 
 ## Contributor License Agreement
 
-All third-party contributions to this project must be accompanied by a signed contributor license. This gives Adobe permission to redistribute your contributions as part of the project. Sign our CLA at [TBD: link coming soon](#). You only need to submit an Adobe CLA one time, so if you have submitted one previously, you are probably good to go!
+All third-party contributions to this project must be accompanied by a signed contributor license. This gives Adobe permission to redistribute your contributions as part of the project. Sign our CLA [here](http://opensource.adobe.com/cla.html). You only need to submit an Adobe CLA one time, so if you have submitted one previously, you are good to go!
 
 ## Code Reviews
 


### PR DESCRIPTION
## Summary of Changes

- Linking up the contribution guidelines to the live Adobe CLA that contributors can sign online.