### PR TITLE
model_id & series_id is a media id

### DIFF
--- a/docs/api/11-search-reference.md
+++ b/docs/api/11-search-reference.md
@@ -191,13 +191,13 @@ Starting with assets that have not commonly been viewed or downloaded.</li></ul>
   <tr>
    <td>search_parameters[model_id]
    </td>
-   <td>Search for assets that portray a specific person (model) using the model's ID. Integer.
+   <td>Search for assets that portray a specific person (model) into a specific media ID. Use a media ID as the value. Integer.
    </td>
   </tr>
   <tr>
    <td>search_parameters[series_id]
    </td>
-   <td>Search for assets in the specified series using the series ID. Returns all assets that the creator has grouped into this single series. Integer.
+   <td>Search for assets in the same series as a media ID. Use a media ID as the value. Integer.
    </td>
   </tr>
   <tr>


### PR DESCRIPTION
# Pull request

## Issue# fixed
Not clearly state that the value must be a media id (stock art file id).

## Summary of Changes
- Added an explicit message about the need to use a media id
- Removed part of the sentence that leads to thinking they were ids different than the media id

## What kind of change does this PR introduce? 
- [X] Enhancement (Clarifying documentation)


