### PR TITLE
Renaming Media/Search series_id search parameter into serie_id

### DIFF
--- a/docs/api/11-search-reference.md
+++ b/docs/api/11-search-reference.md
@@ -195,7 +195,7 @@ Starting with assets that have not commonly been viewed or downloaded.</li></ul>
    </td>
   </tr>
   <tr>
-   <td>search_parameters[series_id]
+   <td>search_parameters[serie_id]
    </td>
    <td>Search for assets in the specified series using the series ID. Returns all assets that the creator has grouped into this single series. Integer.
    </td>


### PR DESCRIPTION
# Pull request

## Issue# fixed
There is no serie**s**_id search parameter (using it will return all stock art insteadO0, instead, it is serie_id

## Summary of Changes
- Renaming series_id to serie_id in the search API function.

## What kind of change does this PR introduce? 
- [X] Technical content bug (Mismatch between doc and the real API)



