### PR TITLE
Fix broken link to developer terms.

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -14,13 +14,10 @@ Before you begin, be sure to review the [Developer Terms of Use](../supplemental
 ## Contents
 <!-- MarkdownTOC -->
 
-- [Getting started with the Adobe Stock API](#getting-started-with-the-adobe-stock-api)
-  - [Read me first!](#read-me-first)
-  - [Contents](#contents)
-  - [Overview](#overview)
-  - [Design phase](#design-phase)
-  - [Next steps](#next-steps)
-  - [More topics](#more-topics)
+- [Overview](#overview)
+- [Design phase](#design-phase)
+- [Next steps](#next-steps)
+- [More topics](#more-topics)
 
 <!-- /MarkdownTOC -->
 

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -9,15 +9,18 @@ curl https://stock.adobe.io/Rest/Media/1/Search/Files?locale=en_US%26search_para
 ```
 
 ## Read me first!
-Before you begin, be sure to review the [Developer Terms of Use](supplemental/terms-for-adobe-stock-developers.md). Or better yet, bookmark it. There will be a quiz later :)
+Before you begin, be sure to review the [Developer Terms of Use](../supplemental/terms-for-adobe-stock-developers.md). Or better yet, bookmark it. There will be a quiz later :)
 
 ## Contents
 <!-- MarkdownTOC -->
 
-- [Overview](#overview)
-- [Design phase](#design-phase)
-- [Next steps](#next-steps)
-- [More topics](#more-topics)
+- [Getting started with the Adobe Stock API](#getting-started-with-the-adobe-stock-api)
+  - [Read me first!](#read-me-first)
+  - [Contents](#contents)
+  - [Overview](#overview)
+  - [Design phase](#design-phase)
+  - [Next steps](#next-steps)
+  - [More topics](#more-topics)
 
 <!-- /MarkdownTOC -->
 


### PR DESCRIPTION
# Pull request
Fix broken link to developer terms.

## Issue# fixed
_Potentially related to #22 , but not mentioned in the issue._

## Summary of Changes
- _Added `../` to terms reference for proper linking._

## What kind of change does this PR introduce? 
- [X] Technical content bug (_Example: HTTP request/response is wrong or incomplete_)
- [ ] Language bug (_Example: spelling/grammar mistake_)
- [ ] Enhancement (_Example: Clarifying or adding missing documentation, or adding language-specific example_)
- [ ] Other: Please explain



