### PR TITLE
I got a 9 back as a media_type_id.

### DIFF
--- a/docs/api/13-license-history.md
+++ b/docs/api/13-license-history.md
@@ -102,7 +102,7 @@ In the table below, fields marked with __*__ are returned by default.
 | *creator_name| Creator Name. String. |
 | *creator_id| Creator unique ID. String. |
 | *content_url| (Deprecated). String. |
-| *media_type_id| Content type of the asset (`1`: Photos, `2`: Illustrations, `3`: Vectors, `4`: Videos, `6`: 3D, `7`: Templates). Integer. |
+| *media_type_id| Content type of the asset (`1`: Photos, `2`: Illustrations, `3`: Vectors, `4`: Videos, `6`: 3D, `7`: Templates, `9`: Audio). Integer. |
 | *vector_type| If the file is a vector indicates if its a svg or a ai/eps (reported as zip). String or Null. |
 | *content_type| Content type of the file (e.g. `image/jpeg`). String. |
 | *height| Item height. Integer. |


### PR DESCRIPTION
I found media_type_id: 9 nowhere in the documentation. What is it?

# Pull request

## Issue# fixed
_Please check if an issue exists, and list the number here._

## Summary of Changes
- _Example: Fixed typo in Licensing API reference_
- _Example: Changed 'http' to 'https' on two pages_

## What kind of change does this PR introduce? 
- [ ] Technical content bug (_Example: HTTP request/response is wrong or incomplete_)
- [ ] Language bug (_Example: spelling/grammar mistake_)
- [ ] Enhancement (_Example: Clarifying or adding missing documentation, or adding language-specific example_)
- [ ] Other: Please explain
- [ ] 



